### PR TITLE
Adds script.js, removes pirates.ttf from cache.addAll

### DIFF
--- a/pirates.html
+++ b/pirates.html
@@ -20,5 +20,7 @@
       Run a shot across the bow snow schooner gabion overhaul boom skysail. Buccaneer Gold Road topmast clipper take a caulk handsomely bucko. Strike colors loot parley black jack Barbary Coast piracy hogshead. Carouser Pirate Round galleon wench keel hearties booty. Dance the hempen jig hail-shot Spanish Main jolly boat mizzenmast Jack Ketch black jack. Fluke topsail line to go on account overhaul doubloon schooner.
     </p>
     <img src="../images/pirate-clip-art.jpg" />
+
+    <script src="./script.js"></script>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -5,7 +5,6 @@ self.addEventListener('install', (event) => {
         [
           '/pirates.html',
           '/styles/pirates.css',
-          '/styles/pirate.ttf',
           '/images/i-love-pirates.jpg'
         ]);
     })

--- a/service-worker.js
+++ b/service-worker.js
@@ -5,7 +5,8 @@ self.addEventListener('install', (event) => {
         [
           '/pirates.html',
           '/styles/pirates.css',
-          '/images/i-love-pirates.jpg'
+          '/images/i-love-pirates.jpg',
+          '/script.js'
         ]);
     })
   );


### PR DESCRIPTION
There is no pirates.ttf, so this causes the service worker install event to fail.