### PR TITLE
Fixes package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "PWA Pirates",
-  "version": "1.0",
+  "name": "pwa-pirates",
+  "version": "1.0.0",
   "dependencies": {
     "localforage": "^1.5.0",
     "sw-precache": "^5.2.0",


### PR DESCRIPTION
The [name and version](https://docs.npmjs.com/files/package.json#name) were invalid so I couldn't install the dependencies.